### PR TITLE
matchNotAhead fix

### DIFF
--- a/src/moon/peg/grammar/Stream.hx
+++ b/src/moon/peg/grammar/Stream.hx
@@ -771,7 +771,7 @@ class Stream
     public inline function matchNotAhead(r:Rule):ParseTree
     {
         var tr = matchPeek(r);
-        return tr == Error ? Empty : tr;
+        return tr == Error ? Empty : Error;
     }
     
     /**


### PR DESCRIPTION
matchNotAhead must return Error if the rule is match
